### PR TITLE
Update a more general saving path in the example slurm script

### DIFF
--- a/macleod/multi_gpu/run_example.sh
+++ b/macleod/multi_gpu/run_example.sh
@@ -16,4 +16,4 @@
 module load anaconda3
 source activate test
 
-srun python example_script.py --epochs=25 --save /home/<username>/sharedscratch/
+srun python example_script.py --epochs=25 --save $HOME/sharedscratch/

--- a/maxwell/multi_gpu/run_example.sh
+++ b/maxwell/multi_gpu/run_example.sh
@@ -16,4 +16,4 @@
 module load miniconda3
 source activate test
 
-srun python example_script.py --epochs=25 --save /home/<username>/sharedscratch/
+srun python example_script.py --epochs=25 --save $HOME/sharedscratch/

--- a/maxwell/single_gpu/run_example.sh
+++ b/maxwell/single_gpu/run_example.sh
@@ -16,4 +16,4 @@
 module load miniconda3
 source activate test
 
-srun python example_script.py --epochs=25 --save /home/<username>/sharedscratch/
+srun python example_script.py --epochs=25 --save $HOME/sharedscratch/


### PR DESCRIPTION
Hi Aiden,

Many thanks for the contribution - I noticed that the saving path in the example slurm script -- `run_example.sh` is `/home/<username>/sharedscratch/`. However, when I submitted the job to the cluster, it raised an error like this: `PermissionError: [Errno 13] Permission denied: '/home/<user-id>'`. Because the correct path on the maxwell server should be: `/uoa/home/<user-id>`. Therefore, I use a more general way to define the saving path: `$HOME/sharedscratch/`.

Best regards,
Tianhong